### PR TITLE
Fix swatches alignment with grid-gap

### DIFF
--- a/src/scss/pickr.scss
+++ b/src/scss/pickr.scss
@@ -107,7 +107,7 @@
     @supports (display: grid) {
         display: grid;
         align-items: center;
-        justify-content: space-around;
+        grid-gap: 10px;
         grid-template-columns: repeat(auto-fit, 1.75em);
     }
 


### PR DESCRIPTION
When you have just a couple of swatches, they're spaced super far apart because of the `justify-content: space-around;` css property. It looks pretty awkward. This PR fixes that.

Example fiddle: <https://jsfiddle.net/yz7cb98q/>